### PR TITLE
Dev v1.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 jtbl changelog
 
+20221004 v1.4.0
+- Add CSV (`-c`) and HTML (`-H`) table output options
+
 20220731 v1.3.2
 - Add `__main__.py` for `python -m jtbl` use cases
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ jtbl changelog
 
 20221004 v1.4.0
 - Add CSV (`-c`) and HTML (`-H`) table output options
+- Preserve column order as much as possible
 
 20220731 v1.3.2
 - Add `__main__.py` for `python -m jtbl` use cases

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 jtbl changelog
 
-20221004 v1.4.0
+20221005 v1.4.0
 - Add CSV (`-c`) and HTML (`-H`) table output options
 - Preserve column order as much as possible
+- Bump tabulate library to v0.8.10
 
 20220731 v1.3.2
 - Add `__main__.py` for `python -m jtbl` use cases

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 jtbl changelog
 
-20221005 v1.4.0
-- Add CSV (`-c`) and HTML (`-H`) table output options
-- Preserve column order as much as possible
+20221006 v1.4.0
+- Add CSV (`-c`) table output option
+- Add HTML (`-H`) table output option
+- Preserve column order when wrapping or truncation is required
 - Bump tabulate library to v0.8.10
 
 20220731 v1.3.2

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ <JSON Data> | jtbl [OPTIONS]
 ```
 ### Options
 - `--cols=n` manually configure the terminal width
+- `-c` CSV table output (overrides `--cols` and `-t`)
+- `-H` HTML table output (overrides `--cols` and `-t`)
 - `-m` markdown table output (overrides `--cols` and `-t`)
 - `-n` no data wrapping if too long for the terminal width (overrides `--cols` and `-t`)
 - `-q` quiet - don't print error messages to STDERR

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ $ <JSON Data> | jtbl [OPTIONS]
 ```
 ### Options
 - `--cols=n` manually configure the terminal width
-- `-c` CSV table output (overrides `--cols` and `-t`)
-- `-H` HTML table output (overrides `--cols` and `-t`)
-- `-m` markdown table output (overrides `--cols` and `-t`)
+- `-c` CSV table output
+- `-H` HTML table output
+- `-m` markdown table output
 - `-n` no data wrapping if too long for the terminal width (overrides `--cols` and `-t`)
 - `-q` quiet - don't print error messages to STDERR
 - `-r` rotate the data (each row turns into a table of key/value pairs)

--- a/jtbl/cli.py
+++ b/jtbl/cli.py
@@ -309,14 +309,8 @@ def main():
     if not succeeded:
         print_error(json_data, quiet=quiet)
 
-    if csv:
-        succeeded, result = make_csv_table(data=json_data, columns=columns)
-        if succeeded:
-            print(result)
-        else:
-            print_error(result, quiet=quiet)
-
-    elif rotate:
+    # Make and print the tables
+    if rotate:
         for idx, row in enumerate(json_data):
             rotated_data = []
             for k, v in row.items():
@@ -335,6 +329,13 @@ def main():
                 print()
             else:
                 print_error(result, quiet=quiet)
+
+    elif csv:
+        succeeded, result = make_csv_table(data=json_data, columns=columns)
+        if succeeded:
+            print(result)
+        else:
+            print_error(result, quiet=quiet)
 
     else:
         succeeded, result = make_table(data=json_data,

--- a/jtbl/cli.py
+++ b/jtbl/cli.py
@@ -195,6 +195,8 @@ def make_csv_table(data=None, columns=0):
                 if isinstance(row, dict):
                     fieldnames.update(row.keys())
 
+        fieldnames = sorted(list(fieldnames))
+
         writer = csv.DictWriter(
             buffer,
             fieldnames,

--- a/jtbl/cli.py
+++ b/jtbl/cli.py
@@ -185,21 +185,21 @@ def make_csv_table(data=None, columns=0):
     succeeded, data = check_data(data=data, columns=columns)
     if succeeded:
         buffer = io.StringIO()
-        fieldnames = set()
+        fieldnames = []
 
         if isinstance(data, dict):
-            fieldnames.update(data.keys())
+            fieldnames.append(data.keys())
 
         elif isinstance(data, list):
             for row in data:
                 if isinstance(row, dict):
-                    fieldnames.update(row.keys())
+                    fieldnames.extend(row.keys())
 
-        fieldnames = sorted(list(fieldnames))
+        headers = dict.fromkeys(fieldnames)
 
         writer = csv.DictWriter(
             buffer,
-            fieldnames,
+            headers.keys(),
             restval='',
             extrasaction='raise',
             dialect='excel'

--- a/jtbl/cli.py
+++ b/jtbl/cli.py
@@ -189,6 +189,40 @@ def get_headers(data):
     return header_dict
 
 
+def make_rotate_table(data=None,
+                      truncate=False,
+                      nowrap=False,
+                      columns=None,
+                      table_format='simple',
+                      rotate=False):
+    """generates a rotated table"""
+    succeeded, data = check_data(data=data, columns=columns)
+
+    if succeeded:
+        table = ''
+        for idx, row in enumerate(data):
+            rotated_data = []
+            for k, v in row.items():
+                rotated_data.append({'key': k, 'value': v})
+
+            succeeded, result = make_table(data=rotated_data,
+                                            truncate=truncate,
+                                            nowrap=nowrap,
+                                            columns=columns,
+                                            table_format=table_format,
+                                            rotate=rotate)
+            if succeeded:
+                if len(data) > 1:
+                    table += f'item: {idx}\n'
+                    table += '─' * columns + '\n'
+                table += result + '\n\n'
+
+        return (SUCCESS, table[:-1])
+
+    else:
+        return (ERROR, data)
+
+
 def make_csv_table(data=None, columns=0):
     succeeded, data = check_data(data=data, columns=columns)
     if succeeded:
@@ -311,24 +345,15 @@ def main():
 
     # Make and print the tables
     if rotate:
-        for idx, row in enumerate(json_data):
-            rotated_data = []
-            for k, v in row.items():
-                rotated_data.append({'key': k, 'value': v})
-
-            succeeded, result = make_table(data=rotated_data,
-                                           truncate=truncate,
-                                           nowrap=nowrap,
-                                           columns=columns,
-                                           rotate=True)
-            if succeeded:
-                if len(json_data) > 1:
-                    print(f'item: {idx}')
-                    print('─' * columns)
-                print(result)
-                print()
-            else:
-                print_error(result, quiet=quiet)
+        succeeded, result = make_rotate_table(data=json_data,
+                                              truncate=truncate,
+                                              nowrap=nowrap,
+                                              columns=columns,
+                                              rotate=True)
+        if succeeded:
+            print(result)
+        else:
+            print_error(result, quiet=quiet)
 
     elif csv:
         succeeded, result = make_csv_table(data=json_data, columns=columns)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tabulate>=0.8.6
+tabulate>=0.8.10

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='jtbl',
-    version='1.3.2',
+    version='1.4.0',
     author='Kelly Brazil',
     author_email='kellyjonbrazil@gmail.com',
     description='A simple cli tool to print JSON and JSON Lines data as a table in the terminal.',

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -204,108 +204,108 @@ class MyTests(unittest.TestCase):
     def test_jc_dig_150cols(self):
         stdin = [{"id": 55658, "opcode": "QUERY", "status": "NOERROR", "flags": ["qr", "rd", "ra"], "query_num": 1, "answer_num": 5, "authority_num": 0, "additional_num": 1, "question": {"name": "www.cnn.com.", "class": "IN", "type": "A"}, "answer": [{"name": "www.cnn.com.", "class": "IN", "type": "CNAME", "ttl": 147, "data": "turner-tls.map.fastly.net."}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.1.67"}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.65.67"}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.129.67"}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.193.67"}], "query_time": 44, "server": "2600", "when": "Wed Mar 18 12:20:59 PDT 2020", "rcvd": 143}]
         expected = textwrap.dedent('''\
-        ╒══════════╤══════════╤═══════╤══════════╤═════════╤══════════╤══════════╤══════════╤══════════╤══════════╤══════════╤══════════╤════════╤════════╕
-        │ opcode   │   server │    id │ status   │ flags   │   query_ │   answer │   author │   additi │ questi   │ answer   │   query_ │ when   │   rcvd │
-        │          │          │       │          │         │      num │     _num │   ity_nu │   onal_n │ on       │          │     time │        │        │
-        │          │          │       │          │         │          │          │        m │       um │          │          │          │        │        │
-        ╞══════════╪══════════╪═══════╪══════════╪═════════╪══════════╪══════════╪══════════╪══════════╪══════════╪══════════╪══════════╪════════╪════════╡
-        │ QUERY    │     2600 │ 55658 │ NOERRO   │ ['qr',  │        1 │        5 │        0 │        1 │ {'name   │ [{'nam   │       44 │ Wed Ma │    143 │
-        │          │          │       │ R        │  'rd',  │          │          │          │          │ ': 'ww   │ e': 'w   │          │ r 18 1 │        │
-        │          │          │       │          │  'ra']  │          │          │          │          │ w.cnn.   │ ww.cnn   │          │ 2:20:5 │        │
-        │          │          │       │          │         │          │          │          │          │ com.',   │ .com.'   │          │ 9 PDT  │        │
-        │          │          │       │          │         │          │          │          │          │  'clas   │ , 'cla   │          │ 2020   │        │
-        │          │          │       │          │         │          │          │          │          │ s': 'I   │ ss': '   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │ N', 't   │ IN', '   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │ ype':    │ type':   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │ 'A'}     │  'CNAM   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ E', 't   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ tl': 1   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 47, 'd   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ata':    │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 'turne   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ r-tls.   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ map.fa   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ stly.n   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ et.'},   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  {'nam   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ e': 't   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ urner-   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ tls.ma   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ p.fast   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ly.net   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ .', 'c   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ lass':   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  'IN',   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  'type   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ': 'A'   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ , 'ttl   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ': 5,    │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 'data'   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ : '151   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ .101.1   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ .67'},   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  {'nam   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ e': 't   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ urner-   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ tls.ma   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ p.fast   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ly.net   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ .', 'c   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ lass':   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  'IN',   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  'type   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ': 'A'   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ , 'ttl   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ': 5,    │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 'data'   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ : '151   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ .101.6   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 5.67'}   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ , {'na   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ me': '   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ turner   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ -tls.m   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ap.fas   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ tly.ne   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ t.', '   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ class'   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ : 'IN'   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ , 'typ   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ e': 'A   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ', 'tt   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ l': 5,   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  'data   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ': '15   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 1.101.   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 129.67   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ '}, {'   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ name':   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  'turn   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ er-tls   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ .map.f   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ astly.   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ net.',   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │  'clas   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ s': 'I   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ N', 't   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ype':    │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 'A', '   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ttl':    │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 5, 'da   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ ta': '   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 151.10   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 1.193.   │          │        │        │
-        │          │          │       │          │         │          │          │          │          │          │ 67'}]    │          │        │        │
-        ╘══════════╧══════════╧═══════╧══════════╧═════════╧══════════╧══════════╧══════════╧══════════╧══════════╧══════════╧══════════╧════════╧════════╛''')
+        ╒═══════╤══════════╤══════════╤═════════╤══════════╤══════════╤══════════╤══════════╤══════════╤══════════╤══════════╤══════════╤════════╤════════╕
+        │    id │ opcode   │ status   │ flags   │   query_ │   answer │   author │   additi │ questi   │ answer   │   query_ │   server │ when   │   rcvd │
+        │       │          │          │         │      num │     _num │   ity_nu │   onal_n │ on       │          │     time │          │        │        │
+        │       │          │          │         │          │          │        m │       um │          │          │          │          │        │        │
+        ╞═══════╪══════════╪══════════╪═════════╪══════════╪══════════╪══════════╪══════════╪══════════╪══════════╪══════════╪══════════╪════════╪════════╡
+        │ 55658 │ QUERY    │ NOERRO   │ ['qr',  │        1 │        5 │        0 │        1 │ {'name   │ [{'nam   │       44 │     2600 │ Wed Ma │    143 │
+        │       │          │ R        │  'rd',  │          │          │          │          │ ': 'ww   │ e': 'w   │          │          │ r 18 1 │        │
+        │       │          │          │  'ra']  │          │          │          │          │ w.cnn.   │ ww.cnn   │          │          │ 2:20:5 │        │
+        │       │          │          │         │          │          │          │          │ com.',   │ .com.'   │          │          │ 9 PDT  │        │
+        │       │          │          │         │          │          │          │          │  'clas   │ , 'cla   │          │          │ 2020   │        │
+        │       │          │          │         │          │          │          │          │ s': 'I   │ ss': '   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │ N', 't   │ IN', '   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │ ype':    │ type':   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │ 'A'}     │  'CNAM   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ E', 't   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ tl': 1   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 47, 'd   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ata':    │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 'turne   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ r-tls.   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ map.fa   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ stly.n   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ et.'},   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  {'nam   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ e': 't   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ urner-   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ tls.ma   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ p.fast   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ly.net   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ .', 'c   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ lass':   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  'IN',   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  'type   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ': 'A'   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ , 'ttl   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ': 5,    │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 'data'   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ : '151   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ .101.1   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ .67'},   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  {'nam   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ e': 't   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ urner-   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ tls.ma   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ p.fast   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ly.net   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ .', 'c   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ lass':   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  'IN',   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  'type   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ': 'A'   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ , 'ttl   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ': 5,    │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 'data'   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ : '151   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ .101.6   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 5.67'}   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ , {'na   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ me': '   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ turner   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ -tls.m   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ap.fas   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ tly.ne   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ t.', '   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ class'   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ : 'IN'   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ , 'typ   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ e': 'A   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ', 'tt   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ l': 5,   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  'data   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ': '15   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 1.101.   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 129.67   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ '}, {'   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ name':   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  'turn   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ er-tls   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ .map.f   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ astly.   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ net.',   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │  'clas   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ s': 'I   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ N', 't   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ype':    │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 'A', '   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ttl':    │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 5, 'da   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ ta': '   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 151.10   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 1.193.   │          │          │        │        │
+        │       │          │          │         │          │          │          │          │          │ 67'}]    │          │          │        │        │
+        ╘═══════╧══════════╧══════════╧═════════╧══════════╧══════════╧══════════╧══════════╧══════════╧══════════╧══════════╧══════════╧════════╧════════╛''')
 
         self.assertEqual(jtbl.cli.make_table(data=stdin, columns=150), (self.SUCCESS, expected))
 
     def test_jc_dig_150cols_t(self):
         stdin = [{"id": 55658, "opcode": "QUERY", "status": "NOERROR", "flags": ["qr", "rd", "ra"], "query_num": 1, "answer_num": 5, "authority_num": 0, "additional_num": 1, "question": {"name": "www.cnn.com.", "class": "IN", "type": "A"}, "answer": [{"name": "www.cnn.com.", "class": "IN", "type": "CNAME", "ttl": 147, "data": "turner-tls.map.fastly.net."}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.1.67"}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.65.67"}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.129.67"}, {"name": "turner-tls.map.fastly.net.", "class": "IN", "type": "A", "ttl": 5, "data": "151.101.193.67"}], "query_time": 44, "server": "2600", "when": "Wed Mar 18 12:20:59 PDT 2020", "rcvd": 143}]
         expected = textwrap.dedent('''\
-        opcode    status      server     id  flags       query_nu    answer_n    authorit    addition  question    answer      query_ti  when       rcvd
-        --------  --------  --------  -----  --------  ----------  ----------  ----------  ----------  ----------  --------  ----------  -------  ------
-        QUERY     NOERROR       2600  55658  ['qr', '           1           5           0           1  {'name':    [{'name'          44  Wed Mar     143''')
+           id  opcode    status    flags       query_nu    answer_n    authorit    addition  question    answer      query_ti    server  when       rcvd
+        -----  --------  --------  --------  ----------  ----------  ----------  ----------  ----------  --------  ----------  --------  -------  ------
+        55658  QUERY     NOERROR   ['qr', '           1           5           0           1  {'name':    [{'name'          44      2600  Wed Mar     143''')
 
         self.assertEqual(jtbl.cli.make_table(data=stdin, truncate=True, columns=150), (self.SUCCESS, expected))
 
@@ -424,6 +424,28 @@ class MyTests(unittest.TestCase):
         | This is a long string that should not be truncated by the markdown table format. Lines should not be wrapped for markdown. |       123 | True      |           |''')
 
         self.assertEqual(jtbl.cli.make_table(data=stdin, columns=self.columns, nowrap=True, table_format='github'), (self.SUCCESS, expected))
+
+
+    def test_add_remove_fields(self):
+        stdin = [{"foo this is a very long long key":"this is a very very long string yes it is"},{"foo this is a very long long key":"medium length string","bar this is another very long string":"now is the time for all good men to come to the aide of their party"},{"baz is yet another long key name":"hello there how are you doing today? I am fine, thank you.","bar this is another very long string":"short string"}]
+        expected = textwrap.dedent('''\
+        ╒════════════════════════════════╤════════════════════════════════╤════════════════════════════════╕
+        │ foo this is a very long long   │ bar this is another very lon   │ baz is yet another long key    │
+        │  key                           │ g string                       │ name                           │
+        ╞════════════════════════════════╪════════════════════════════════╪════════════════════════════════╡
+        │ this is a very very long str   │                                │                                │
+        │ ing yes it is                  │                                │                                │
+        ├────────────────────────────────┼────────────────────────────────┼────────────────────────────────┤
+        │ medium length string           │ now is the time for all good   │                                │
+        │                                │  men to come to the aide of    │                                │
+        │                                │ their party                    │                                │
+        ├────────────────────────────────┼────────────────────────────────┼────────────────────────────────┤
+        │                                │ short string                   │ hello there how are you doin   │
+        │                                │                                │ g today? I am fine, thank yo   │
+        │                                │                                │ u.                             │
+        ╘════════════════════════════════╧════════════════════════════════╧════════════════════════════════╛''')
+
+        self.assertEqual(jtbl.cli.make_table(data=stdin, columns=100), (self.SUCCESS, expected))
 
 
 if __name__ == '__main__':

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -30,23 +30,11 @@ class MyTests(unittest.TestCase):
 
     def test_null_string(self):
         stdin = [None]
-        expected = textwrap.dedent('''\
-        jtbl:  Cannot represent this part of the JSON Object as a table.
-               (Could be an Element, an Array, or Null data instead of an Object):
-               [null]
-        ''')
-
-        self.assertEqual(jtbl.cli.make_table(data=stdin, columns=self.columns), (self.ERROR, expected))
+        self.assertRaises(AttributeError, jtbl.cli.make_table, data=stdin, columns=self.columns)
 
     def test_array_input(self):
         stdin = ["value1", "value2", "value3"]
-        expected = textwrap.dedent('''\
-        jtbl:  Cannot represent this part of the JSON Object as a table.
-               (Could be an Element, an Array, or Null data instead of an Object):
-               ["value1", "value2", "value3"]
-        ''')
-
-        self.assertEqual(jtbl.cli.make_table(data=stdin, columns=self.columns), (self.ERROR, expected))
+        self.assertRaises(AttributeError, jtbl.cli.make_table, data=stdin, columns=self.columns)
 
     def test_deep_nest(self):
         stdin = [{"this":{"is":{"a":{"deeply":{"nested":{"structure":"value1","item2":"value2"}}}}}}]

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -427,6 +427,7 @@ class MyTests(unittest.TestCase):
 
 
     def test_add_remove_fields(self):
+        """test with added and missing fields"""
         stdin = [{"foo this is a very long long key":"this is a very very long string yes it is"},{"foo this is a very long long key":"medium length string","bar this is another very long string":"now is the time for all good men to come to the aide of their party"},{"baz is yet another long key name":"hello there how are you doing today? I am fine, thank you.","bar this is another very long string":"short string"}]
         expected = textwrap.dedent('''\
         ╒════════════════════════════════╤════════════════════════════════╤════════════════════════════════╕
@@ -446,6 +447,196 @@ class MyTests(unittest.TestCase):
         ╘════════════════════════════════╧════════════════════════════════╧════════════════════════════════╛''')
 
         self.assertEqual(jtbl.cli.make_table(data=stdin, columns=100), (self.SUCCESS, expected))
+
+
+    def test_csv(self):
+        """test csv output"""
+        stdin = [{"LatD":"41","LatM":"5","LatS":"59","NS":"N","LonD":"80","LonM":"39","LonS":"0","EW":"W","City":"Youngstown","State":"OH"},{"LatD":"42","LatM":"52","LatS":"48","NS":"N","LonD":"97","LonM":"23","LonS":"23","EW":"W","City":"Yankton","State":"SD"},{"LatD":"46","LatM":"35","LatS":"59","NS":"N","LonD":"120","LonM":"30","LonS":"36","EW":"W","City":"Yakima","State":"WA"},{"LatD":"42","LatM":"16","LatS":"12","NS":"N","LonD":"71","LonM":"48","LonS":"0","EW":"W","City":"Worcester","State":"MA"},{"LatD":"43","LatM":"37","LatS":"48","NS":"N","LonD":"89","LonM":"46","LonS":"11","EW":"W","City":"Wisconsin Dells","State":"WI"},{"LatD":"36","LatM":"5","LatS":"59","NS":"N","LonD":"80","LonM":"15","LonS":"0","EW":"W","City":"Winston-Salem","State":"NC"},{"LatD":"49","LatM":"52","LatS":"48","NS":"N","LonD":"97","LonM":"9","LonS":"0","EW":"W","City":"Winnipeg","State":"MB"},{"LatD":"39","LatM":"11","LatS":"23","NS":"N","LonD":"78","LonM":"9","LonS":"36","EW":"W","City":"Winchester","State":"VA"},{"LatD":"34","LatM":"14","LatS":"24","NS":"N","LonD":"77","LonM":"55","LonS":"11","EW":"W","City":"Wilmington","State":"NC"}]
+        expected = textwrap.dedent('''\
+        LatD,LatM,LatS,NS,LonD,LonM,LonS,EW,City,State\r
+        41,5,59,N,80,39,0,W,Youngstown,OH\r
+        42,52,48,N,97,23,23,W,Yankton,SD\r
+        46,35,59,N,120,30,36,W,Yakima,WA\r
+        42,16,12,N,71,48,0,W,Worcester,MA\r
+        43,37,48,N,89,46,11,W,Wisconsin Dells,WI\r
+        36,5,59,N,80,15,0,W,Winston-Salem,NC\r
+        49,52,48,N,97,9,0,W,Winnipeg,MB\r
+        39,11,23,N,78,9,36,W,Winchester,VA\r
+        34,14,24,N,77,55,11,W,Wilmington,NC\r
+        ''')
+
+        self.assertEqual(jtbl.cli.make_csv_table(data=stdin), (self.SUCCESS, expected))
+
+
+    def test_html(self):
+        """test html output"""
+        stdin = [{"LatD":"41","LatM":"5","LatS":"59","NS":"N","LonD":"80","LonM":"39","LonS":"0","EW":"W","City":"Youngstown","State":"OH"},{"LatD":"42","LatM":"52","LatS":"48","NS":"N","LonD":"97","LonM":"23","LonS":"23","EW":"W","City":"Yankton","State":"SD"},{"LatD":"46","LatM":"35","LatS":"59","NS":"N","LonD":"120","LonM":"30","LonS":"36","EW":"W","City":"Yakima","State":"WA"},{"LatD":"42","LatM":"16","LatS":"12","NS":"N","LonD":"71","LonM":"48","LonS":"0","EW":"W","City":"Worcester","State":"MA"},{"LatD":"43","LatM":"37","LatS":"48","NS":"N","LonD":"89","LonM":"46","LonS":"11","EW":"W","City":"Wisconsin Dells","State":"WI"},{"LatD":"36","LatM":"5","LatS":"59","NS":"N","LonD":"80","LonM":"15","LonS":"0","EW":"W","City":"Winston-Salem","State":"NC"},{"LatD":"49","LatM":"52","LatS":"48","NS":"N","LonD":"97","LonM":"9","LonS":"0","EW":"W","City":"Winnipeg","State":"MB"},{"LatD":"39","LatM":"11","LatS":"23","NS":"N","LonD":"78","LonM":"9","LonS":"36","EW":"W","City":"Winchester","State":"VA"},{"LatD":"34","LatM":"14","LatS":"24","NS":"N","LonD":"77","LonM":"55","LonS":"11","EW":"W","City":"Wilmington","State":"NC"}]
+
+        expected = textwrap.dedent('''\
+        <table>
+        <thead>
+        <tr><th style="text-align: right;">  LatD</th><th style="text-align: right;">  LatM</th><th style="text-align: right;">  LatS</th><th>NS  </th><th style="text-align: right;">  LonD</th><th style="text-align: right;">  LonM</th><th style="text-align: right;">  LonS</th><th>EW  </th><th>City           </th><th>State  </th></tr>
+        </thead>
+        <tbody>
+        <tr><td style="text-align: right;">    41</td><td style="text-align: right;">     5</td><td style="text-align: right;">    59</td><td>N   </td><td style="text-align: right;">    80</td><td style="text-align: right;">    39</td><td style="text-align: right;">     0</td><td>W   </td><td>Youngstown     </td><td>OH     </td></tr>
+        <tr><td style="text-align: right;">    42</td><td style="text-align: right;">    52</td><td style="text-align: right;">    48</td><td>N   </td><td style="text-align: right;">    97</td><td style="text-align: right;">    23</td><td style="text-align: right;">    23</td><td>W   </td><td>Yankton        </td><td>SD     </td></tr>
+        <tr><td style="text-align: right;">    46</td><td style="text-align: right;">    35</td><td style="text-align: right;">    59</td><td>N   </td><td style="text-align: right;">   120</td><td style="text-align: right;">    30</td><td style="text-align: right;">    36</td><td>W   </td><td>Yakima         </td><td>WA     </td></tr>
+        <tr><td style="text-align: right;">    42</td><td style="text-align: right;">    16</td><td style="text-align: right;">    12</td><td>N   </td><td style="text-align: right;">    71</td><td style="text-align: right;">    48</td><td style="text-align: right;">     0</td><td>W   </td><td>Worcester      </td><td>MA     </td></tr>
+        <tr><td style="text-align: right;">    43</td><td style="text-align: right;">    37</td><td style="text-align: right;">    48</td><td>N   </td><td style="text-align: right;">    89</td><td style="text-align: right;">    46</td><td style="text-align: right;">    11</td><td>W   </td><td>Wisconsin Dells</td><td>WI     </td></tr>
+        <tr><td style="text-align: right;">    36</td><td style="text-align: right;">     5</td><td style="text-align: right;">    59</td><td>N   </td><td style="text-align: right;">    80</td><td style="text-align: right;">    15</td><td style="text-align: right;">     0</td><td>W   </td><td>Winston-Salem  </td><td>NC     </td></tr>
+        <tr><td style="text-align: right;">    49</td><td style="text-align: right;">    52</td><td style="text-align: right;">    48</td><td>N   </td><td style="text-align: right;">    97</td><td style="text-align: right;">     9</td><td style="text-align: right;">     0</td><td>W   </td><td>Winnipeg       </td><td>MB     </td></tr>
+        <tr><td style="text-align: right;">    39</td><td style="text-align: right;">    11</td><td style="text-align: right;">    23</td><td>N   </td><td style="text-align: right;">    78</td><td style="text-align: right;">     9</td><td style="text-align: right;">    36</td><td>W   </td><td>Winchester     </td><td>VA     </td></tr>
+        <tr><td style="text-align: right;">    34</td><td style="text-align: right;">    14</td><td style="text-align: right;">    24</td><td>N   </td><td style="text-align: right;">    77</td><td style="text-align: right;">    55</td><td style="text-align: right;">    11</td><td>W   </td><td>Wilmington     </td><td>NC     </td></tr>
+        </tbody>
+        </table>''')
+
+        self.assertEqual(jtbl.cli.make_table(data=stdin, columns=self.columns, nowrap=True, table_format='html'), (self.SUCCESS, expected))
+
+
+    def test_rotate(self):
+        """test html output"""
+        stdin = [{"LatD":"41","LatM":"5","LatS":"59","NS":"N","LonD":"80","LonM":"39","LonS":"0","EW":"W","City":"Youngstown","State":"OH"},{"LatD":"42","LatM":"52","LatS":"48","NS":"N","LonD":"97","LonM":"23","LonS":"23","EW":"W","City":"Yankton","State":"SD"},{"LatD":"46","LatM":"35","LatS":"59","NS":"N","LonD":"120","LonM":"30","LonS":"36","EW":"W","City":"Yakima","State":"WA"},{"LatD":"42","LatM":"16","LatS":"12","NS":"N","LonD":"71","LonM":"48","LonS":"0","EW":"W","City":"Worcester","State":"MA"},{"LatD":"43","LatM":"37","LatS":"48","NS":"N","LonD":"89","LonM":"46","LonS":"11","EW":"W","City":"Wisconsin Dells","State":"WI"},{"LatD":"36","LatM":"5","LatS":"59","NS":"N","LonD":"80","LonM":"15","LonS":"0","EW":"W","City":"Winston-Salem","State":"NC"},{"LatD":"49","LatM":"52","LatS":"48","NS":"N","LonD":"97","LonM":"9","LonS":"0","EW":"W","City":"Winnipeg","State":"MB"},{"LatD":"39","LatM":"11","LatS":"23","NS":"N","LonD":"78","LonM":"9","LonS":"36","EW":"W","City":"Winchester","State":"VA"},{"LatD":"34","LatM":"14","LatS":"24","NS":"N","LonD":"77","LonM":"55","LonS":"11","EW":"W","City":"Wilmington","State":"NC"}]
+
+        expected = textwrap.dedent('''\
+        item: 0
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   41
+        LatM   5
+        LatS   59
+        NS     N
+        LonD   80
+        LonM   39
+        LonS   0
+        EW     W
+        City   Youngstown
+        State  OH
+
+        item: 1
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   42
+        LatM   52
+        LatS   48
+        NS     N
+        LonD   97
+        LonM   23
+        LonS   23
+        EW     W
+        City   Yankton
+        State  SD
+
+        item: 2
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   46
+        LatM   35
+        LatS   59
+        NS     N
+        LonD   120
+        LonM   30
+        LonS   36
+        EW     W
+        City   Yakima
+        State  WA
+
+        item: 3
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   42
+        LatM   16
+        LatS   12
+        NS     N
+        LonD   71
+        LonM   48
+        LonS   0
+        EW     W
+        City   Worcester
+        State  MA
+
+        item: 4
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   43
+        LatM   37
+        LatS   48
+        NS     N
+        LonD   89
+        LonM   46
+        LonS   11
+        EW     W
+        City   Wisconsin Dells
+        State  WI
+
+        item: 5
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   36
+        LatM   5
+        LatS   59
+        NS     N
+        LonD   80
+        LonM   15
+        LonS   0
+        EW     W
+        City   Winston-Salem
+        State  NC
+
+        item: 6
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   49
+        LatM   52
+        LatS   48
+        NS     N
+        LonD   97
+        LonM   9
+        LonS   0
+        EW     W
+        City   Winnipeg
+        State  MB
+
+        item: 7
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   39
+        LatM   11
+        LatS   23
+        NS     N
+        LonD   78
+        LonM   9
+        LonS   36
+        EW     W
+        City   Winchester
+        State  VA
+
+        item: 8
+        ────────────────────────────────────────────────────────────────────────────────
+        LatD   34
+        LatM   14
+        LatS   24
+        NS     N
+        LonD   77
+        LonM   55
+        LonS   11
+        EW     W
+        City   Wilmington
+        State  NC
+        ''')
+
+        self.assertEqual(jtbl.cli.make_rotate_table(data=stdin, columns=self.columns, nowrap=True, rotate=True), (self.SUCCESS, expected))
+
+
+    def test_rotate_single_item(self):
+        """test html output"""
+        stdin = [{"LatD":"41","LatM":"5","LatS":"59","NS":"N","LonD":"80","LonM":"39","LonS":"0","EW":"W","City":"Youngstown","State":"OH"}]
+
+        expected = textwrap.dedent('''\
+        LatD   41
+        LatM   5
+        LatS   59
+        NS     N
+        LonD   80
+        LonM   39
+        LonS   0
+        EW     W
+        City   Youngstown
+        State  OH
+        ''')
+
+        self.assertEqual(jtbl.cli.make_rotate_table(data=stdin, columns=self.columns, nowrap=True, rotate=True), (self.SUCCESS, expected))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Add CSV (`-c`) table output option
- Add HTML (`-H`) table output option
- Preserve column order when wrapping or truncation is required
- Bump tabulate library to v0.8.10